### PR TITLE
Load PacketEvents internally

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -110,6 +110,7 @@ shadowJar {
     relocate("org.bstats", "${shadePath}bstats")
     relocate("net.kyori", "${shadePath}kyori")
     relocate("com.alessiodp.libby", "${shadePath}libby")
+    relocate("com.github.retrooper.packetevents", "${shadePath}packetevents")
     archiveFileName = "itsmyconfig-${project.version}.jar"
 }
 

--- a/core/src/main/java/to/itsme/itsmyconfig/ItsMyConfig.java
+++ b/core/src/main/java/to/itsme/itsmyconfig/ItsMyConfig.java
@@ -5,6 +5,8 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
+import com.github.retrooper.packetevents.PacketEvents;
+import io.github.retrooper.packetevents.factory.spigot.SpigotPacketEventsBuilder;
 import to.itsme.itsmyconfig.api.ItsMyConfigAPI;
 import to.itsme.itsmyconfig.command.CommandManager;
 import to.itsme.itsmyconfig.listener.PlayerListener;
@@ -65,6 +67,16 @@ public final class ItsMyConfig extends JavaPlugin {
     }
 
     @Override
+    public void onLoad() {
+        instance = this;
+        LibraryLoader.loadLibraries();
+        if (LibraryLoader.PACKET_EVENTS.shouldLoad()) {
+            PacketEvents.setAPI(SpigotPacketEventsBuilder.build(this));
+            PacketEvents.getAPI().load();
+        }
+    }
+
+    @Override
     public void onEnable() {
         this.getLogger().info("Loading ItsMyConfig...");
         if (Versions.isBelow(1, 16, 5)) {
@@ -74,7 +86,6 @@ public final class ItsMyConfig extends JavaPlugin {
         }
 
         final long start = System.currentTimeMillis();
-        instance = this;
         api = new DefaultIMCAPI(this);
         this.getServer().getServicesManager().register(
                 ItsMyConfigAPI.class,
@@ -82,7 +93,6 @@ public final class ItsMyConfig extends JavaPlugin {
                 this,
                 org.bukkit.plugin.ServicePriority.Normal
         );
-        LibraryLoader.loadLibraries();
         AudienceResolver.load(this);
         List.of("imc", "itsmyconfig").forEach(alias -> new PAPIHook(this, alias).register());
         new CommandManager(this);

--- a/core/src/main/java/to/itsme/itsmyconfig/processor/ProcessorManager.java
+++ b/core/src/main/java/to/itsme/itsmyconfig/processor/ProcessorManager.java
@@ -5,6 +5,7 @@ import org.bukkit.plugin.PluginManager;
 import to.itsme.itsmyconfig.ItsMyConfig;
 import to.itsme.itsmyconfig.processor.packetevents.PEventsListener;
 import to.itsme.itsmyconfig.processor.protocollib.PLibListener;
+import to.itsme.itsmyconfig.util.reflect.Reflections;
 
 import java.util.*;
 
@@ -29,11 +30,14 @@ public class ProcessorManager {
 
         final Map<String, Integer> availableListeners = new HashMap<>();
 
-        for (String key : Set.of("PacketEvents", "ProtocolLib")) {
-            if (manager.getPlugin(key) != null) {
-                int priority = configSection.getInt(key + ".priority", Integer.MAX_VALUE);
-                availableListeners.put(key, priority);
-            }
+        if (Reflections.findClass("to{}itsme{}itsmyconfig{}shade{}packetevents.PacketEvents")) {
+            int priority = configSection.getInt("PacketEvents.priority", Integer.MAX_VALUE);
+            availableListeners.put("PacketEvents", priority);
+        }
+
+        if (manager.getPlugin("ProtocolLib") != null) {
+            int priority = configSection.getInt("ProtocolLib.priority", Integer.MAX_VALUE);
+            availableListeners.put("ProtocolLib", priority);
         }
 
         if (availableListeners.isEmpty()) {

--- a/core/src/main/java/to/itsme/itsmyconfig/processor/packetevents/PEventsListener.java
+++ b/core/src/main/java/to/itsme/itsmyconfig/processor/packetevents/PEventsListener.java
@@ -40,6 +40,7 @@ public class PEventsListener implements PacketListener, com.github.retrooper.pac
 
     @Override
     public void load() {
+        PacketEvents.getAPI().init();
         this.common = PacketEvents.getAPI().getEventManager().registerListener(this, PacketListenerPriority.NORMAL);
     }
 
@@ -110,5 +111,6 @@ public class PEventsListener implements PacketListener, com.github.retrooper.pac
     @Override
     public void close() {
         PacketEvents.getAPI().getEventManager().unregisterListener(this.common);
+        PacketEvents.getAPI().terminate();
     }
 }

--- a/core/src/main/java/to/itsme/itsmyconfig/processor/packetevents/PEventsProcessor.java
+++ b/core/src/main/java/to/itsme/itsmyconfig/processor/packetevents/PEventsProcessor.java
@@ -8,25 +8,11 @@ import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 import to.itsme.itsmyconfig.processor.PacketContent;
 import to.itsme.itsmyconfig.processor.PacketProcessor;
-import to.itsme.itsmyconfig.util.AdventureUtil;
 import to.itsme.itsmyconfig.util.IMCSerializer;
-
-import java.lang.reflect.Method;
 
 public class PEventsProcessor {
 
     public static final PacketProcessor<WrapperPlayServerChatMessage> CHAT_MESSAGE = new PacketProcessor<>() {
-        private final Method getChatContent, setChatContent;
-
-        {
-            try {
-                getChatContent = ChatMessage.class.getMethod("getChatContent");
-                setChatContent = ChatMessage.class.getMethod("setChatContent", AdventureUtil.getComponentClass());
-            } catch (Throwable t) {
-                throw new RuntimeException("Failed to resolve setChatContent method", t);
-            }
-        }
-
         @Override
         public String name() {
             return "CHAT_MESSAGE";
@@ -34,40 +20,18 @@ public class PEventsProcessor {
 
         @Override
         public void edit(WrapperPlayServerChatMessage wrappedPacket, Component component) {
-            Object chatContent = AdventureUtil.fromComponent(component);
-            Object chatMessage = wrappedPacket.getMessage();
-            try {
-                setChatContent.invoke(chatMessage, chatContent);
-            } catch (Throwable t) {
-                throw new RuntimeException("Failed to invoke setChatContent", t);
-            }
+            ChatMessage chatMessage = wrappedPacket.getMessage();
+            chatMessage.setChatContent(component);
         }
 
         @Override
         public @NotNull PacketContent<WrapperPlayServerChatMessage> unpack(WrapperPlayServerChatMessage wrappedPacket) {
-            Object chatContent;
-            try {
-                chatContent = getChatContent.invoke(wrappedPacket.getMessage());
-            } catch (Throwable t) {
-                throw new RuntimeException("Failed to invoke getChatContent", t);
-            }
-            Component internal = AdventureUtil.toComponent(chatContent);
+            Component internal = wrappedPacket.getMessage().getChatContent();
             return new PacketContent<>(wrappedPacket, this, IMCSerializer.toMiniMessage(internal));
         }
     };
 
     public static final PacketProcessor<WrapperPlayServerSystemChatMessage> SYSTEM_CHAT_MESSAGE = new PacketProcessor<>() {
-        private final Method getMessage, setMessage;
-
-        {
-            try {
-                getMessage = WrapperPlayServerSystemChatMessage.class.getMethod("getMessage");
-                setMessage = WrapperPlayServerSystemChatMessage.class.getMethod("setMessage", AdventureUtil.getComponentClass());
-            } catch (Throwable t) {
-                throw new RuntimeException("Failed to resolve setMessage method", t);
-            }
-        }
-
         @Override
         public String name() {
             return "SYSTEM_CHAT_MESSAGE";
@@ -75,39 +39,17 @@ public class PEventsProcessor {
 
         @Override
         public void edit(WrapperPlayServerSystemChatMessage wrappedPacket, Component component) {
-            Object externalComponent = AdventureUtil.fromComponent(component);
-            try {
-                setMessage.invoke(wrappedPacket, externalComponent);
-            } catch (Throwable t) {
-                throw new RuntimeException("Failed to invoke setMessage", t);
-            }
+            wrappedPacket.setMessage(component);
         }
 
         @Override
         public @NotNull PacketContent<WrapperPlayServerSystemChatMessage> unpack(WrapperPlayServerSystemChatMessage wrappedPacket) {
-            Object externalComponent;
-            try {
-                externalComponent = getMessage.invoke(wrappedPacket);
-            } catch (Throwable t) {
-                throw new RuntimeException("Failed to invoke WrapperPlayServerSystemChatMessage#getMessage", t);
-            }
-            Component internal = AdventureUtil.toComponent(externalComponent);
+            Component internal = wrappedPacket.getMessage();
             return new PacketContent<>(wrappedPacket, this, IMCSerializer.toMiniMessage(internal));
         }
     };
 
     public static final PacketProcessor<WrapperPlayServerDisconnect> DISCONNECT = new PacketProcessor<>() {
-        private final Method getReason, setReason;
-
-        {
-            try {
-                getReason = WrapperPlayServerDisconnect.class.getMethod("getReason");
-                setReason = WrapperPlayServerDisconnect.class.getMethod("setReason", AdventureUtil.getComponentClass());
-            } catch (Throwable t) {
-                throw new RuntimeException("Failed to resolve setReason method", t);
-            }
-        }
-
         @Override
         public String name() {
             return "DISCONNECT";
@@ -115,23 +57,12 @@ public class PEventsProcessor {
 
         @Override
         public void edit(WrapperPlayServerDisconnect wrappedPacket, Component component) {
-            Object externalComponent = AdventureUtil.fromComponent(component);
-            try {
-                setReason.invoke(wrappedPacket, externalComponent);
-            } catch (Throwable t) {
-                throw new RuntimeException("Failed to invoke setReason", t);
-            }
+            wrappedPacket.setReason(component);
         }
 
         @Override
         public @NotNull PacketContent<WrapperPlayServerDisconnect> unpack(WrapperPlayServerDisconnect wrappedPacket) {
-            Object externalComponent;
-            try {
-                externalComponent = getReason.invoke(wrappedPacket);
-            } catch (Throwable t) {
-                throw new RuntimeException("Failed to invoke WrapperPlayServerDisconnect#getReason", t);
-            }
-            Component internal = AdventureUtil.toComponent(externalComponent);
+            Component internal = wrappedPacket.getReason();
             return new PacketContent<>(wrappedPacket, this, IMCSerializer.toMiniMessage(internal));
         }
     };

--- a/core/src/main/java/to/itsme/itsmyconfig/util/LibraryLoader.java
+++ b/core/src/main/java/to/itsme/itsmyconfig/util/LibraryLoader.java
@@ -44,6 +44,21 @@ public enum LibraryLoader {
             "adventure-text-serializer-gson",
             BuildParameters.ADVENTURE_VERSION,
             () -> !Reflections.findClass("net{}kyori{}adventure{}text.serializer.gson.GsonSerializer")
+    ),
+    PACKET_EVENTS(
+            "com{}github{}retrooper",
+            "packetevents-spigot",
+            "2.9.4",
+            "https://jitpack.io",
+            () -> true,
+            new Relocation(
+                    String.join(".", "com", "github", "retrooper", "packetevents"),
+                    BuildParameters.SHADE_PATH + "packetevents"
+            ),
+            new Relocation(
+                    String.join(".", "net", "kyori"),
+                    BuildParameters.SHADE_PATH + "kyori"
+            )
     );
 
     private static final LibraryManager MANAGER = new BukkitLibraryManager(ItsMyConfig.getInstance());

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -9,4 +9,3 @@ depend:
   - PlaceholderAPI
 softdepend:
   - ProtocolLib
-  - PacketEvents


### PR DESCRIPTION
## Summary
- load PacketEvents via Libby on plugin load and bootstrap API before enable
- initialize and register PacketEvents listener during enable
- bootstrap PacketEvents API lifecycle ourselves
- relocate Adventure classes inside the PacketEvents library
- simplify PacketEvents processors to use Adventure components directly

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_b_68ac7092ac608327b07eca54e3c70457